### PR TITLE
Have `detect` accept `&[Joint]` rather than `&Skeleton` for flexibility

### DIFF
--- a/examples/playback.rs
+++ b/examples/playback.rs
@@ -40,7 +40,7 @@ fn main() -> io::Result<()> {
             }
         }
         for skeleton in data.skeletons() {
-            println!("Detecting {:?}", detector.detect(&skeleton));
+            println!("Detecting {:?}", detector.detect(skeleton.joints()));
         }
     }).expect("Failed to create skeleton callback");
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@ use nuitrack_rs as nui;
 
 mod poses;
 
-use self::nui::{JointType, Skeleton};
+use self::nui::{Joint, JointType};
 use glm::{Mat2x2, Vec2};
 use na::MatrixMN;
 use std::cell::RefCell;
@@ -112,12 +112,12 @@ impl Detector {
     }
 
     /// Detect if there is a pose in this skeleton
-    pub fn detect(&self, skeleton: &Skeleton) -> Option<Pose> {
+    pub fn detect(&self, skeleton: &[Joint]) -> Option<Pose> {
         let joints = joints_map(skeleton);
         self.check_poses(joints)
     }
 
-    fn detect_pose(&self, name: Pose, skeleton: &Skeleton) -> Option<f32> {
+    fn detect_pose(&self, name: Pose, skeleton: &[Joint]) -> Option<f32> {
         let mut joints = joints_map(skeleton);
         let pose = self
             .poses
@@ -193,15 +193,14 @@ impl Tester {
         Tester { name, detector }
     }
 
-    pub fn test(&self, skeleton: &Skeleton) -> Option<Pose> {
+    pub fn test(&self, skeleton: &[Joint]) -> Option<Pose> {
         let found = self.detector.detect_pose(self.name, skeleton);
         found.map(|_| self.name)
     }
 }
 
-fn joints_map(skeleton: &Skeleton) -> JointPos {
+fn joints_map(skeleton: &[Joint]) -> JointPos {
     let joints = skeleton
-        .joints()
         .iter()
         .map(|j| (JointType::from_u32(j.type_), j))
         .filter(|(t, _)| t.is_some())

--- a/tests/poses.rs
+++ b/tests/poses.rs
@@ -3,7 +3,7 @@ use nuitrack_pose_estimation as pe;
 use nuitrack_rs;
 
 use glm::Vec2;
-use nuitrack_rs::{feed_to_ptr, Joint, JointType, Orientation, SkeletonFeed, Vector3};
+use nuitrack_rs::{Joint, JointType, Orientation, SkeletonFeed, Vector3};
 use pe::{Detector, Pose, PoseData, Settings};
 use std::collections::HashMap;
 use std::iter::FromIterator;
@@ -76,10 +76,9 @@ fn match_identity() {
         rotation_cutoff: 0.34,
         joint_cutoff: 0.01,
     };
-    let skeleton = vec![skeleton(&mock_skeleton)];
-    let skeleton_ptr = feed_to_ptr(&skeleton);
+    let skeleton = skeleton(&mock_skeleton);
     let tester = Detector::with_poses(settings, dab_r());
-    let result = tester.detect(&skeleton_ptr[0]);
+    let result = tester.detect(&skeleton.joints);
     assert_eq!(result, Some(Pose::DabR));
 }
 
@@ -93,10 +92,9 @@ fn match_close() {
         rotation_cutoff: 0.34,
         joint_cutoff: 0.01,
     };
-    let skeleton = vec![skeleton(&mock_skeleton)];
-    let skeleton_ptr = feed_to_ptr(&skeleton);
+    let skeleton = skeleton(&mock_skeleton);
     let tester = Detector::with_poses(settings, dab_r());
-    let result = tester.detect(&skeleton_ptr[0]);
+    let result = tester.detect(&skeleton.joints);
     assert_eq!(result, Some(Pose::DabR));
 }
 
@@ -110,10 +108,9 @@ fn nomatch_joint_cutoff() {
         rotation_cutoff: 0.34,
         joint_cutoff: 0.01,
     };
-    let skeleton = vec![skeleton(&mock_skeleton)];
-    let skeleton_ptr = feed_to_ptr(&skeleton);
+    let skeleton = skeleton(&mock_skeleton);
     let tester = Detector::with_poses(settings, dab_r());
-    let result = tester.detect(&skeleton_ptr[0]);
+    let result = tester.detect(&skeleton.joints);
     assert_eq!(result, None);
 }
 
@@ -128,10 +125,9 @@ fn nomatch_rotation_cutoff() {
         rotation_cutoff: 0.34,
         joint_cutoff: 0.01,
     };
-    let skeleton = vec![skeleton(&mock_skeleton)];
-    let skeleton_ptr = feed_to_ptr(&skeleton);
+    let skeleton = skeleton(&mock_skeleton);
     let tester = Detector::with_poses(settings, dab_r());
-    let result = tester.detect(&skeleton_ptr[0]);
+    let result = tester.detect(&skeleton.joints);
     assert_eq!(result, None);
 }
 
@@ -147,10 +143,9 @@ fn match_rotation_close() {
         rotation_cutoff: 0.34,
         joint_cutoff: 0.08,
     };
-    let skeleton = vec![skeleton(&mock_skeleton)];
-    let skeleton_ptr = feed_to_ptr(&skeleton);
+    let skeleton = skeleton(&mock_skeleton);
     let tester = Detector::with_poses(settings, dab_r());
-    let result = tester.detect(&skeleton_ptr[0]);
+    let result = tester.detect(&skeleton.joints);
     assert_eq!(result, Some(Pose::DabR));
 }
 
@@ -165,10 +160,9 @@ fn match_allign() {
         rotation_cutoff: 0.34,
         joint_cutoff: 0.01,
     };
-    let skeleton = vec![skeleton(&mock_skeleton)];
-    let skeleton_ptr = feed_to_ptr(&skeleton);
+    let skeleton = skeleton(&mock_skeleton);
     let tester = Detector::with_poses(settings, dab_r());
-    let result = tester.detect(&skeleton_ptr[0]);
+    let result = tester.detect(&skeleton.joints);
     assert_eq!(result, Some(Pose::DabR));
 }
 
@@ -182,9 +176,8 @@ fn match_scale() {
         rotation_cutoff: 0.34,
         joint_cutoff: 0.01,
     };
-    let skeleton = vec![skeleton(&mock_skeleton)];
-    let skeleton_ptr = feed_to_ptr(&skeleton);
+    let skeleton = skeleton(&mock_skeleton);
     let tester = Detector::with_poses(settings, dab_r());
-    let result = tester.detect(&skeleton_ptr[0]);
+    let result = tester.detect(&skeleton.joints);
     assert_eq!(result, Some(Pose::DabR));
 }


### PR DESCRIPTION
Only accepting `Skeleton` makes it tricky to do detection on a thread
other than the one on which the callbacks are run. This PR allows for
doing detection on both the skeletons produced via `SkeletonData` as
well as user owned skeleton types, as long as a slice of `Joint`s is
accessible.